### PR TITLE
Don't use popups, they are blocked in browsers

### DIFF
--- a/action.php
+++ b/action.php
@@ -31,7 +31,7 @@ class action_plugin_multiorphan extends DokuWiki_Action_Plugin {
 
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handle_ajax_call_unknown');
         $controller->register_hook('MULTIORPHAN_INSTRUCTION_LINKED', 'BEFORE', $this, 'handle_unknown_instructions');
-   
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'extend_JSINFO');
     }
 
     /**
@@ -334,6 +334,11 @@ class action_plugin_multiorphan extends DokuWiki_Action_Plugin {
         }
 
         return false;
+    }
+
+    public function extend_JSINFO($event, $param) {
+        global $JSINFO;
+        $JSINFO['schemes'] = array_values(getSchemes());
     }
 
     private function _init_http_client() {

--- a/script.js
+++ b/script.js
@@ -9,8 +9,12 @@
         view : function(type) {
             return {
                 label: 'View',
+                actionId: 'view',
                 click: function() {
                     var $link = jQuery(this);
+                    if (type === 'Page') {
+                        return true;
+                    }
                     request({'do':'view'+type, 'link':decodeURIComponent($link.attr('elementid'))}, function(response){
 
                         if ( response.dialogContent ) {
@@ -25,9 +29,6 @@
                                     jQuery(this).dialog('close').remove();
                                 } 
                             }).html(response.dialogContent);
-                        } else if ( response.link ) {
-                            var win = window.open(response.link, '_blank');
-                            win.focus();
                         }
                     });
                     return false;
@@ -141,7 +142,15 @@
         // Add actions
         var $buttonSet = jQuery('<div/>').addClass('actions').appendTo($insertPoint);
         jQuery.each(actions||[], function(idx, action) {
-            var $link = jQuery('<a href=""/>').attr('elementid', id).text(action.label).appendTo($buttonSet).click(action.click);
+            const attrs = {
+                href: '',
+                elementid: id,
+            };
+            if (action.actionId === 'view') {
+                attrs.href = DOKU_BASE + 'doku.php?id=' + id;
+                attrs.target = '_blank';
+            }
+            var $link = jQuery('<a>').attr(attrs).text(action.label).appendTo($buttonSet).click(action.click);
             if ( action.process ) {
                 action.process($link);
             }
@@ -167,7 +176,7 @@
 
         if ( requestPage && requestPage.length ) {
             var $entry = jQuery('<li/>').addClass('requestPage').text(requestPage).appendTo($appendTo);
-            guiElementActions(actions, requestPage, $entry);
+            guiElementActions([ORPHANACTIONS.view('Page')], requestPage, $entry);
         }
     };
 

--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@
                 actionId: 'view',
                 click: function() {
                     var $link = jQuery(this);
-                    if (type === 'Page') {
+                    if (type === 'Page' || type === 'URL') {
                         return true;
                     }
                     request({'do':'view'+type, 'link':decodeURIComponent($link.attr('elementid'))}, function(response){
@@ -137,6 +137,20 @@
         validateElement();
     };
 
+    var buildUrl = function (id) {
+        var cleanedID = decodeURIComponent(id);
+        var schemeSepPos = cleanedID.indexOf('://');
+        if (schemeSepPos > -1) {
+            var scheme = cleanedID.substr(0, schemeSepPos);
+            if (JSINFO.schemes.indexOf(scheme) > -1) {
+                // we have an external url
+                return cleanedID;
+            }
+        }
+
+        return DOKU_BASE + 'doku.php?id=' + id;
+    };
+
     var guiElementActions = function(actions, id, $insertPoint) {
 
         // Add actions
@@ -147,7 +161,7 @@
                 elementid: id,
             };
             if (action.actionId === 'view') {
-                attrs.href = DOKU_BASE + 'doku.php?id=' + id;
+                attrs.href = buildUrl(id);
                 attrs.target = '_blank';
             }
             var $link = jQuery('<a>').attr(attrs).text(action.label).appendTo($buttonSet).click(action.click);


### PR DESCRIPTION
Basically, all modern browsers (or at least Firefox and Chrome) block
popups (i.e. windows opened by `window.open`) by default. So this makes
for a suboptimal user experience.

The way around this is to add the final URL and target="_blank" to the
link by default and let the browser execute the default action.

When creating the link, it is necessary to differentiate between the
different actions. We currently could use the `label`-key, however, at
some point, we might want to localize that 'label' key. Hence an `actionId`
is added to reliably identify the action.

This should fix #20 

PS: I we could now remove the `viewPage` and `viewUrl` cases from the ajax handler in the backend?