### PR TITLE
Improve styling of the results

### DIFF
--- a/script.js
+++ b/script.js
@@ -166,7 +166,8 @@
         }
 
         if ( requestPage && requestPage.length ) {
-            var $entry = jQuery('<li/>').addClass('requestPage').text(requestPage).appendTo($appendTo);
+            var $pageId = jQuery('<span>').text(requestPage);
+            var $entry = jQuery('<li>').addClass('requestPage').append($pageId).appendTo($appendTo);
             guiElementActions(actions, requestPage, $entry);
         }
     };

--- a/style.less
+++ b/style.less
@@ -69,6 +69,12 @@
             padding: 0.5em 1em;
             background-color: #fefefe;
 
+            > span {
+                display: inline-block;
+                width: 80%;
+                word-break: break-all;
+            }
+
             &:nth-child(even) {
                 background-color: #efefef;
             }
@@ -94,9 +100,14 @@
             }
         }
 
-        li {
-
+        li.requestPage {
             position: relative;
+
+            > span {
+                display: inline-block;
+                width: 80%;
+                vertical-align: text-top;
+            }
 
             div.actions:hover:before {
                 content: '';

--- a/style.less
+++ b/style.less
@@ -97,7 +97,6 @@
         li {
 
             position: relative;
-            white-space: pre;
 
             div.actions:hover:before {
                 content: '';

--- a/style.less
+++ b/style.less
@@ -10,7 +10,7 @@
     fieldset {
 
         text-align: left;
-        min-width: 0; // this makes the fieldset behave correctly.
+        min-width: 60%; // this makes the fieldset behave correctly.
 
         label {
 


### PR DESCRIPTION
The pull request fixes the issue that the "View"-link will be unclickable if it flows to the next line and that line already contains the next item.

Note: The Line 13 in style.less contains the comment ` // this makes the fieldset behave correctly.`. I was unable to reproduce the incorrect behavior that this line is intended to fix, so I'm unsure whether I have broken it accidentally.