### PR TITLE
Fix broken deletes and resolve PHP notices

### DIFF
--- a/action.php
+++ b/action.php
@@ -104,7 +104,7 @@ class action_plugin_multiorphan extends DokuWiki_Action_Plugin {
             
             case 'deletePage' : {
                 
-                $link = $INPUT->str('link');
+                $link = urldecode($INPUT->str('link'));
                 saveWikiText($link, '', "Remove page via multiORPHANS");
                 break;
             }
@@ -143,7 +143,7 @@ class action_plugin_multiorphan extends DokuWiki_Action_Plugin {
             
             case 'deleteMedia' : {
                 
-                $link = $INPUT->str('link');
+                $link = urldecode($INPUT->str('link'));
                 $status = media_delete($link, $AUTH);
                 break;
             }


### PR DESCRIPTION
The delete actions were not working because the ID in the ajax-request had been URL-encoded. This has been fixed in a6a3503.

Further, the second commit 2ab7429 fixes several PHP notices that occurred while using this plugin.