### PR TITLE
Fix script.js deprecated message on errors

### DIFF
--- a/script.js
+++ b/script.js
@@ -368,7 +368,7 @@
             return;
         }
 
-        if (!$('#multiorphan__errorlog').size()) {
+        if (!$('#multiorphan__errorlog').length) {
             $('#multiorphan__out').parent().append($('<div id="multiorphan__errorlog"/>'));
         }
 


### PR DESCRIPTION
``size()`` has been deprecated, uses ``length`` instead. https://stackoverflow.com/questions/54411842/uncaught-typeerror-size-is-not-a-function