### PR TITLE
Fix: Use safe explode (sexplode)

### DIFF
--- a/action/multiorphan.php
+++ b/action/multiorphan.php
@@ -227,7 +227,7 @@ class action_plugin_multiorphan_multiorphan extends DokuWiki_Action_Plugin {
         $mid = $data['entryID'];
         $hash = null;
         if (strpos($mid, '#') !== false) {
-            list($mid, $hash) = explode('#', $mid); //record pages without hashs
+            list($mid, $hash) = sexplode('#', $mid); //record pages without hashs
         }
 
 		$isLocalLink = $data['syntax'] == 'locallink';
@@ -434,7 +434,7 @@ class action_plugin_multiorphan_multiorphan extends DokuWiki_Action_Plugin {
     private function hrefForType( $type, $id ) {
         switch( $type ) {
             case 'pages':
-                list($link, $hash) = explode('#', $id, 2);
+                list($link, $hash) = sexplode('#', $id, 2);
                 if ( !empty( $hash) ) {
                     $this->_init_renderer();
                     $hash = '#' . $this->renderer->_headerToLink( $hash );


### PR DESCRIPTION
Error parsing answer:

Warning: Undefined array key 1 in /home/nethouse/wiki/lib/plugins/multiorphan/action/multiorphan.php on line 437

This is a PHP warning, indicating that the ``explode()`` function, when used with '#' as the delimiter on the variable ``$id``, did not find a '#' character. As a result, the resulting array only has one element (index 0), and when you try to access index 1 (i.e., ``$hash``), it's "undefined.

This ensures the array always has a minimum number of elements, filling missing ones with a default value (null by default).