### PR TITLE
Fix internallink detection

### DIFF
--- a/action/multiorphan.php
+++ b/action/multiorphan.php
@@ -315,6 +315,12 @@ class action_plugin_multiorphan_multiorphan extends DokuWiki_Action_Plugin {
                     $this->_plugin_input_to_header( $input, $data );
                 }
 
+                if ( $input[0] == 'internallink' ) {
+                    $info = array();
+                    $output = p_render('xhtml', $instructions, $info);
+                    return strpos($output, 'id="'.strtolower($data['entryID']).'"');
+                }
+
                 if ( $input[0] != 'header' ) {
                     return $data['exists'];
                 }


### PR DESCRIPTION
Renders the page to check if a header with the specified hash exists (e.g. ":trasa#trasa1" will search for "trasa1" hash inside "trasa" page).